### PR TITLE
Update for Core v3, php8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # nais-cs
 Coding styles rules and git hook for NAIS Based Applications
 
+v3.1.0
+* Require PHP 8.3+
+* `UnionTypeHintFormat` replaced with `DNFTypeHintFormat` (Slevomat CS 8.16+)
+* Ruleset: typed class constants (`ClassConstantTypeHint`), `ConstantSpacing`
+* Custom sniffs: native `int` parameters, `enum_exists()` in `StringClassReferenceSniff`
+* Composer plugin: `void` return types, Composer 2 plugin API only
+
 v3.0.0
 * Require PHP 8.1
 * Update slevomat/coding-standard to v8

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
   "homepage": "https://movisio.com",
   "license": ["BSD-3-Clause", "GPL-2.0", "GPL-3.0"],
   "require": {
-    "php": ">=8.1",
-    "composer-plugin-api": "^1.0 || ^2.0",
-    "slevomat/coding-standard": "8.*"
+    "php": ">=8.3",
+    "composer-plugin-api": "^2.0",
+    "slevomat/coding-standard": "^8.15"
   },
   "autoload": {
     "psr-4": {
@@ -19,7 +19,7 @@
     "class": "NaisCodingStandard\\ComposerPlugin"
   },
   "require-dev": {
-    "composer/composer": "dev-master"
+    "composer/composer": "^2.7",
+    "squizlabs/php_codesniffer": "^3.9"
   }
 }
-

--- a/config/ruleset.xml
+++ b/config/ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="naisProject">
-    <description>Coding standarts for NAIS project</description>
+    <description>Coding standards for NAIS project (PHP 8.3+)</description>
     <rule ref="PSR12">
         <exclude name="PSR12.Functions.ReturnTypeDeclaration.SpaceBeforeColon" />
         <exclude name="PSR12.Files.FileHeader.SpacingAfterTagBlock" />
@@ -39,7 +39,6 @@
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation"/>
     </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
             <property name="linesCountBeforeDeclare" type="int" value="0"/>
@@ -126,14 +125,17 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
-    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
     <rule ref="NaisCodingStandard.Commenting.RequiredComments"/>
     <rule ref="NaisCodingStandard.Classes.StringClassReference"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.PHP.Syntax"/>
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+    <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint">
+        <exclude name="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint.UselessDocComment"/>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat"/>
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
 
     <!-- other sniffs to include -->

--- a/src/NaisCodingStandard/ComposerPlugin.php
+++ b/src/NaisCodingStandard/ComposerPlugin.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 namespace NaisCodingStandard;
 
 use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
-use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 
@@ -15,21 +15,21 @@ use Composer\Script\ScriptEvents;
  */
 class ComposerPlugin implements PluginInterface, EventSubscriberInterface
 {
-    private const HOOK_FILE = '/../bash/pre-commit';
-    private const GIT_DIR = '/../../../../../.git';
-    private const HOOK_DESTINATION = '/../../../../../.git/hooks';
+    private const string HOOK_FILE = '/../bash/pre-commit';
+
+    private const string GIT_DIR = '/../../../../../.git';
+
+    private const string HOOK_DESTINATION = '/../../../../../.git/hooks';
 
     /**
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
-     * @param Composer $composer
-     * @param IOInterface $io
      */
     public function activate(Composer $composer, IOInterface $io) : void
     {
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public static function getSubscribedEvents() : array
     {
@@ -40,27 +40,39 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
-     * Install the hook
-     * @param Event $event
+     * Install the pre-commit hook when the project root contains .git.
      */
     public function onPostInstallUpdateCmd(Event $event) : void
     {
-        if (!is_dir(__DIR__ . self::GIT_DIR)) {
-            $event->getIO()->writeError('Directory "' . __DIR__ . self::GIT_DIR . '" not found. Installation of git hook failed');
+        $gitDir = __DIR__ . self::GIT_DIR;
+        if (!is_dir($gitDir)) {
+            $event->getIO()->writeError(
+                'Directory "' . $gitDir . '" not found. Installation of git hook failed'
+            );
+
             return;
         }
-        if (!is_dir(__DIR__ . self::HOOK_DESTINATION)) {
-            mkdir(__DIR__ . self::HOOK_DESTINATION);
+
+        $hookDestination = __DIR__ . self::HOOK_DESTINATION;
+        if (!is_dir($hookDestination)) {
+            mkdir($hookDestination);
         }
-        copy(__DIR__ . self::HOOK_FILE, __DIR__ . self::HOOK_DESTINATION . '/pre-commit');
-        chmod(__DIR__ . self::HOOK_DESTINATION . '/pre-commit', 0775);
+
+        copy(__DIR__ . self::HOOK_FILE, $hookDestination . '/pre-commit');
+        chmod($hookDestination . '/pre-commit', 0775);
     }
 
-    public function deactivate(Composer $composer, IOInterface $io)
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
+     */
+    public function deactivate(Composer $composer, IOInterface $io) : void
     {
     }
 
-    public function uninstall(Composer $composer, IOInterface $io)
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
+     */
+    public function uninstall(Composer $composer, IOInterface $io) : void
     {
     }
 }

--- a/src/NaisCodingStandard/Sniffs/Classes/StringClassReferenceSniff.php
+++ b/src/NaisCodingStandard/Sniffs/Classes/StringClassReferenceSniff.php
@@ -3,16 +3,16 @@ declare(strict_types = 1);
 
 namespace NaisCodingStandard\Sniffs\Classes;
 
-use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * Class StringClassReferenceSniff - kontrola tridy jako stringu a jeji nahrazeni za ::class
+ * Kontrola třídy jako řetězce a náhrada za ::class.
  */
 class StringClassReferenceSniff implements Sniff
 {
     /**
-     * @return array
+     * @return array<int, int|string>
      */
     public function register() : array
     {
@@ -20,24 +20,30 @@ class StringClassReferenceSniff implements Sniff
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
      * @param File $phpcsFile
-     * @param int $stackPtr
      */
-    public function process(File $phpcsFile, $stackPtr) : void
+    public function process(File $phpcsFile, int $stackPtr) : void
     {
         $tokens = $phpcsFile->getTokens();
-        if (strpos($tokens[$stackPtr]['content'], '\\') !== false) {
-            // Remove quotes from string
-            $className = str_replace(['"', "'"], '', $tokens[$stackPtr]['content']);
-            if ($className === '\\') {
-                return;
-            }
-            if (class_exists($className) || interface_exists($className) || trait_exists($className)) {
-                $error = 'String "%s" contains class reference, use ::class instead';
-                $data = [$className];
-                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
-            }
+        if (!str_contains($tokens[$stackPtr]['content'], '\\')) {
+            return;
+        }
+
+        // Remove quotes from string
+        $className = str_replace(['"', "'"], '', $tokens[$stackPtr]['content']);
+        if ($className === '\\') {
+            return;
+        }
+
+        if (
+            class_exists($className)
+            || interface_exists($className)
+            || trait_exists($className)
+            || enum_exists($className)
+        ) {
+            $error = 'String "%s" contains class reference, use ::class instead';
+            $data = [$className];
+            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
         }
     }
 }

--- a/src/NaisCodingStandard/Sniffs/Commenting/RequiredCommentsSniff.php
+++ b/src/NaisCodingStandard/Sniffs/Commenting/RequiredCommentsSniff.php
@@ -16,7 +16,7 @@ use function sprintf;
  */
 class RequiredCommentsSniff implements Sniff
 {
-    public const CODE_COMMENT_REQUIRED = 'CommentRequired';
+    public const string CODE_COMMENT_REQUIRED = 'CommentRequired';
 
     /**
      * @return mixed[]
@@ -30,11 +30,9 @@ class RequiredCommentsSniff implements Sniff
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $definitionPointer
+     * @param File $phpcsFile
      */
-    public function process(File $phpcsFile, $definitionPointer) : void
+    public function process(File $phpcsFile, int $definitionPointer) : void
     {
         $hasDocComment = DocCommentHelper::hasDocComment($phpcsFile, $definitionPointer);
 


### PR DESCRIPTION
v3.1.0
* Require PHP 8.3+
* `UnionTypeHintFormat` replaced with `DNFTypeHintFormat` (Slevomat CS 8.16+)
* Ruleset: typed class constants (`ClassConstantTypeHint`), `ConstantSpacing`
* Custom sniffs: native `int` parameters, `enum_exists()` in `StringClassReferenceSniff`
* Composer plugin: `void` return types, Composer 2 plugin API only